### PR TITLE
chore: Adjust tsconfig and Mocha settings for ESM support

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,0 +1,6 @@
+{
+	"require": "ts-node/register",
+	"extension": ["ts"],
+	"spec": "test/**/*.test.ts",
+	"watch-files": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/package.json
+++ b/package.json
@@ -7,11 +7,11 @@
 		"fetchdoc": "./dist/index.js"
 	},
 	"scripts": {
-		"build": "rollup -c",
+		"build": "tsc -p tsconfig.json && rollup -c",
 		"start": "node ./dist/index.js",
 		"lint": "eslint 'src/**/*.{js,ts}'",
 		"lint:fix": "eslint 'src/**/*.{js,ts}' --fix",
-		"test": "mocha -r ts-node/register 'test/**/*.test.ts'",
+		"test": "TS_NODE_PROJECT=tsconfig.test.json mocha --require ts-node/register test/**/*.test.ts",
 		"version": "auto-changelog -p && git add CHANGELOG.md",
 		"postbuild": "chmod +x dist/index.js"
 	},

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -12,13 +12,14 @@ export default {
 		format: 'cjs',
 		banner: '#!/usr/bin/env node',
 	},
-	external: ['tslib', 'child_process', 'axios'],
+	external: ['tslib', 'child_process', 'axios', 'yargs'],
 	plugins: [
 		typescript({ exclude: 'node_modules' }),
 		nodeResolve({ exportConditions: ['node'], preferBuiltins: false }),
 		commonjs({ includes: 'node_modules/**' }),
 		json(),
 		replace({
+			preventAssignment: true,
 			VERSION: JSON.stringify(pkg.version),
 		}),
 	],

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,7 +55,7 @@ yargs(hideBin(process.argv))
 		description: 'Display the README in the terminal',
 	})
 	.help()
-	.wrap(yargs.terminalWidth())
+	.wrap(process.stdout.columns || 80)
 	.check((argv) => {
 		if (!argv.package) {
 			throw new Error('The <package> argument is required.')

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
 	"compilerOptions": {
 		"rootDir": "./src",
 		"target": "ESNext",
-		"module": "CommonJS",
+		"module": "ESNext",
 		"esModuleInterop": true,
 		"moduleResolution": "node",
 		"forceConsistentCasingInFileNames": true,

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+	"compilerOptions": {
+		"target": "ESNext",
+		"module": "CommonJS",
+		"esModuleInterop": true,
+		"moduleResolution": "node",
+		"strict": true,
+		"noEmit": true,
+		"skipLibCheck": true
+	},
+	"include": ["test/**/*.ts"],
+	"exclude": ["node_modules"]
+}


### PR DESCRIPTION
- Updated tsconfig.test.json for CommonJS module resolution.
- Modified Mocha test script to ensure correct tsconfig is used.
- Attempted various configurations to resolve ESM loader issues with Node v18.16.0.

Note: Further investigation may be needed to fully support ESM with the current Node version.